### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ To get a local copy up and running follow these simple example steps.
    ```sh
    node index.js
    ```
-4. Move to the frontend directory and start the React frontend:
+4. Move to the frontend directory, install NPM packages and start the React frontend:
    ```sh
    cd frontend
+   npm install
    npm start
    ```
 


### PR DESCRIPTION
`npm start` may fail to execute if React is not globally installed on the developer's machine. Adding another step to the getting started section to reflect that.